### PR TITLE
Add Kaizo Client for language message

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -18,7 +18,7 @@
 
 | Project | Details |
 | ------- | ------- |
-| | |
+| [Kaizo Client](https://github.com/M0REKZ/kaizo-client) | Client will send one or multiple messages with a language code from /languages/index.txt based on selected client language |
 
 **DESCRIPTION**:
 


### PR DESCRIPTION
I added language message support to my client, it does not follow the mentioned standard but will follow whatever standard DDNet has in index.txt (currently the one mentioned in #18)